### PR TITLE
Redefine  $forbiddenFunctions from protected to public, as defined in ba...

### DIFF
--- a/modules/vendor/phpcs/rulesets/Drupal/Sniffs/Functions/DiscouragedFunctionsSniff.php
+++ b/modules/vendor/phpcs/rulesets/Drupal/Sniffs/Functions/DiscouragedFunctionsSniff.php
@@ -27,7 +27,7 @@ class Drupal_Sniffs_Functions_DiscouragedFunctionsSniff extends Generic_Sniffs_P
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                      // Devel module debugging functions.
                                      'dargs'               => null,
                                      'dcp'                 => null,

--- a/modules/vendor/phpcs/rulesets/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/modules/vendor/phpcs/rulesets/WordPress/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -33,7 +33,7 @@ class WordPress_Sniffs_PHP_DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                      'print_r'                  => null,
                                      'ereg_replace'             => 'preg_replace',
                                      'ereg'                     => null,

--- a/modules/vendor/phpcs/rulesets/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
+++ b/modules/vendor/phpcs/rulesets/WordPress/Sniffs/VIP/FileSystemWritesDisallowSniff.php
@@ -20,7 +20,7 @@ class WordPress_Sniffs_VIP_FileSystemWritesDisallowSniff extends Generic_Sniffs_
 	 *
 	 * @var array(string => string|null)
 	 */
-	protected $forbiddenFunctions = array(
+	public $forbiddenFunctions = array(
 										'file_put_contents' => null,
 										'fwrite'            => null,
 										'fputcsv'           => null,

--- a/modules/vendor/phpcs/rulesets/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
+++ b/modules/vendor/phpcs/rulesets/WordPress/Sniffs/VIP/SessionFunctionsUsageSniff.php
@@ -20,7 +20,7 @@ class WordPress_Sniffs_VIP_SessionFunctionsUsageSniff extends Generic_Sniffs_PHP
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                     'session_cache_expire'      => null,
                                     'session_cache_limiter'     => null,
                                     'session_commit'            => null,

--- a/modules/vendor/phpcs/rulesets/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
+++ b/modules/vendor/phpcs/rulesets/WordPress/Sniffs/VIP/TimezoneChangeSniff.php
@@ -20,7 +20,7 @@ class WordPress_Sniffs_VIP_TimezoneChangeSniff extends Generic_Sniffs_PHP_Forbid
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = array(
+    public $forbiddenFunctions = array(
                                     'date_default_timezone_set'      => null,
                                     );
 


### PR DESCRIPTION
Fix access level errors by switching declarations of $forbiddenFunctions (array) from protected to public in sub-classes of Generic_Sniffs_PHP_ForbiddenFunctionsSniff. Affects 5 sniffs for Wordpress & Drupal.

Sample error:
PHP Fatal error:  Access level to WordPress_Sniffs_PHP_DiscouragedFunctionsSniff::$forbiddenFunctions must be public (as in class Generic_Sniffs_PHP_ForbiddenFunctionsSniff) in ..